### PR TITLE
Stop breaking every time there's a new stable node release

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,5 +7,5 @@
     "main" : "gdata.js",
     "dependencies": {},
     "repository" : {"type": "git" , "url": "http://github.com/smurthas/gdata-js.git" },
-    "engines": { "node": ">=0.4.6 <=0.4.11" }
+    "engines": { "node": ">=0.4.6 <0.5.0" }
 }


### PR DESCRIPTION
Any version under 0.5.0 will most likely be fine, it's purely bug fixes going in
