### PR TITLE
Handle long refresh token response

### DIFF
--- a/gdata.js
+++ b/gdata.js
@@ -17,14 +17,18 @@ function doPost(body, callback) {
 
   var httpsReq = https.request(options, function (httpsRes) {
     if (httpsRes.statusCode === 200) {
-      httpsRes.on('data', function (data) {
+      var fullbody = "";
+      httpsRes.on('data', function (chunk) {
+        fullbody += chunk.toString();
+      });
+      httpsRes.on('end', function(){
         var res;
         try {
-          res = JSON.parse(data.toString());
+          res = JSON.parse(fullbody.toString());
         } catch(err) {
           return callback({
             err: err,
-            res: data
+            res: fullbody
           });
         }
         callback(null, res);


### PR DESCRIPTION
Add http response chunks to a temp string before parsing the entire output.

I had to make this change to get my refresh token flow to work.